### PR TITLE
#26 [Bug] 초대 링크 OG 이미지의 잘못된 프로필 이미지 랜더링

### DIFF
--- a/main.py
+++ b/main.py
@@ -203,7 +203,7 @@ async def eventInviteHandler(inviterId: str):
         }
 
         # load background image
-        img_og = Image.fromarray(images["background.{}.eventInvite".format(event_type)])
+        img_og = Image.fromarray(images["background.{}.eventInvite".format(event_type)]).convert("RGBA")
         draw = ImageDraw.Draw(img_og, "RGBA")
 
         # draw nickname

--- a/main.py
+++ b/main.py
@@ -191,6 +191,11 @@ async def eventInviteHandler(inviterId: str):
             raise ValueError("eventInviteHandler : Invalid profileImageUrl")
         img_profile = Image.open(BytesIO(res_profile.content))
 
+        # convert rgb(a) to bgr(a) format (cv2 uses bgr format)
+        img_profile_array = np.array(img_profile)
+        img_profile_array[..., :3] = img_profile_array[..., :3][..., ::-1]
+        img_profile = Image.fromarray(img_profile_array)
+
         # convert inviter information to text
         text = {
             "nickname": inviterInfo["nickname"],
@@ -214,6 +219,8 @@ async def eventInviteHandler(inviterId: str):
         draw.text((31, 140), text["message"], font=fonts["eventInvite"]["message"], fill=colors["white"])
 
         # draw profile image
+        if min(img_profile.size) > 245:
+            img_profile = img_profile.crop((0, 0, min(img_profile.size), min(img_profile.size)))
         img_profile = img_profile.resize((245, 245))
 
         scale_factor = 4 # for anti-aliasing


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #26 
cv2에서는 BGR(A) 포맷을 사용하는데, PIL에서는 RGB(A) 포맷을 사용하여 발생한 문제였습니다.

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->
![image](https://github.com/user-attachments/assets/6b9bdc53-606c-4db4-a81a-b2a782e6e70d)
![image](https://github.com/user-attachments/assets/43834b4b-5e50-4a7a-8212-09fcfd3b387f)
![image](https://github.com/user-attachments/assets/fd1322f5-bd28-492d-80bc-7e83b800754b)

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- Nothing
